### PR TITLE
Improve HandleNumber method.

### DIFF
--- a/NS.CalviScript/NS.CalviScript.Tests/TokenizerTests.cs
+++ b/NS.CalviScript/NS.CalviScript.Tests/TokenizerTests.cs
@@ -216,5 +216,22 @@ namespace NS.CalviScript.Tests
             Assert.That( t7.Type, Is.EqualTo( TokenType.SemiColon ) );
             Assert.That( t8.Type, Is.EqualTo( TokenType.End ) );
         }
+
+        [TestCase("0", TokenType.Number, "0")]
+        [TestCase("1", TokenType.Number, "1")]
+        [TestCase("01", TokenType.Error, "01")]
+        [TestCase("10", TokenType.Number, "10")]
+        [TestCase("0name", TokenType.Error, "0n")]
+        [TestCase("1name", TokenType.Error, "1n")]
+        [TestCase("123name", TokenType.Error, "123n")]
+        public void handle_numbers(string input, TokenType expectedType, string expectedValue)
+        {
+            Tokenizer sut = new Tokenizer(input);
+
+            sut.GetNextToken();
+
+            Assert.That(sut.CurrentToken.Type, Is.EqualTo(expectedType));
+            Assert.That(sut.CurrentToken.Value, Is.EqualTo(expectedValue));
+        }
     }
 }

--- a/NS.CalviScript/NS.CalviScript/Tokenizer.cs
+++ b/NS.CalviScript/NS.CalviScript/Tokenizer.cs
@@ -138,6 +138,12 @@ namespace NS.CalviScript
 
         bool IsNumber => char.IsDigit( Peek() );
 
+        /// <summary>
+        /// Create a new <see cref="Token"/> and moves forward.
+        /// The number should be a zero only, or start with a digit from 1 to 9 followed by any number of digit from 0 to 9.
+        /// A number must not be immediately followed by an identifer.
+        /// </summary>
+        /// <returns>A new <see cref="Token"/>.</returns>
         Token HandleNumber()
         {
             Debug.Assert( IsNumber );
@@ -145,7 +151,7 @@ namespace NS.CalviScript
             if( Peek() == '0' )
             {
                 Forward();
-                if( !IsEnd && IsNumber ) return new Token( TokenType.Error, Peek() );
+                if( !IsEnd && (IsNumber || IsIdentifier) ) return new Token( TokenType.Error, "0" + Peek() );
                 return new Token( TokenType.Number, '0' );
             }
 
@@ -155,6 +161,12 @@ namespace NS.CalviScript
                 sb.Append( Peek() );
                 Forward();
             } while( !IsEnd && IsNumber );
+
+            if (!IsEnd && IsIdentifier)
+            {
+                sb.Append(Peek());
+                return new Token(TokenType.Error, sb.ToString());
+            }
 
             return new Token( TokenType.Number, sb.ToString() );
         }


### PR DESCRIPTION
Improve the Tokenizer Number Handler to return an Error Token if they are immediately followed by an identifier.
Add a general test case for handling numbers.