### PR TITLE
Add support for nested multi line comments.

### DIFF
--- a/NS.CalviScript/NS.CalviScript.Tests/TokenizerTests.cs
+++ b/NS.CalviScript/NS.CalviScript.Tests/TokenizerTests.cs
@@ -1,10 +1,12 @@
 ﻿using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace NS.CalviScript.Tests
 {
     [TestFixture]
     public class TokenizerTests
     {
+        [TestCase( " ", TokenType.End )]
         [TestCase( "+", TokenType.Plus )]
         [TestCase( "(", TokenType.LeftParenthesis )]
         public void parse_string_containing_1_token( string input, TokenType expected )
@@ -134,6 +136,39 @@ namespace NS.CalviScript.Tests
             Assert.That( t2.Type, Is.EqualTo( TokenType.Plus ) );
             Assert.That( t3.Type, Is.EqualTo( TokenType.Number ) );
             Assert.That( t4.Type, Is.EqualTo( TokenType.End ) );
+        }
+
+        [TestCase("/*", TokenType.Error)]
+        [TestCase("*/", TokenType.Mult, TokenType.Div)]
+        [TestCase("/**/", TokenType.End)]
+        [TestCase("1 /* 2 + 2 */ /* var x */ x", TokenType.Number, TokenType.Identifier, TokenType.End)]
+        [TestCase("1 /* \r\n\r\n */ /* \r\n */ x", TokenType.Number, TokenType.Identifier, TokenType.End)]
+        [TestCase("1 /* 2 + 2 */ /* var x */ x /* */", TokenType.Number, TokenType.Identifier, TokenType.End)]
+        public void parse_multiline_comments(string input, params TokenType[] expected)
+        {
+            Tokenizer tokenizer = new Tokenizer(input);
+            List<TokenType> expectedTokens = new List<TokenType>(expected);
+
+            foreach (TokenType token in expectedTokens)
+            {
+                tokenizer.GetNextToken();
+                Assert.That(tokenizer.CurrentToken.Type, Is.EqualTo(token));
+            }
+        }
+
+        [TestCase("/*/**/*/", TokenType.End)]
+        [TestCase("/* /* */", TokenType.Error)]
+        [TestCase("1 /* 2 /* 3 */ 4 */ z", TokenType.Number, TokenType.Identifier, TokenType.End)]
+        public void parse_nested_multiline_comments(string input, params TokenType[] expected)
+        {
+            Tokenizer tokenizer = new Tokenizer(input);
+            List<TokenType> expectedTokens = new List<TokenType>(expected);
+
+            foreach (TokenType token in expectedTokens)
+            {
+                tokenizer.GetNextToken();
+                Assert.That(tokenizer.CurrentToken.Type, Is.EqualTo(token));
+            }
         }
 
         [Test]

--- a/NS.CalviScript/NS.CalviScript/Tokenizer.cs
+++ b/NS.CalviScript/NS.CalviScript/Tokenizer.cs
@@ -172,7 +172,9 @@ namespace NS.CalviScript
                         return error;
                 }
                 else
+                {
                     Forward();
+                }
             }
 
             if (IsEnd(1))

--- a/NS.CalviScript/NS.CalviScript/Tokenizer.cs
+++ b/NS.CalviScript/NS.CalviScript/Tokenizer.cs
@@ -16,15 +16,17 @@ namespace NS.CalviScript
 
         public Token GetNextToken()
         {
-            if( IsEnd ) return CurrentToken = new Token( TokenType.End );
-
-            while( IsWhiteSpace || IsComment )
+            Token result = null;
+            while (!IsEnd() &&( IsWhiteSpace || IsComment || IsMultiLineComment ))
             {
                 if( IsWhiteSpace ) HandleWhiteSpaces();
                 if( IsComment ) HandleComment();
+                if (IsMultiLineComment) result = HandleMultiLineComment();
+                if (result != null) return CurrentToken = result;
             }
 
-            Token result;
+            if (IsEnd()) return CurrentToken = new Token(TokenType.End);
+
             if( Peek() == '+' ) result = HandleSimpleToken( TokenType.Plus );
             else if( Peek() == '-' ) result = HandleSimpleToken( TokenType.Minus );
             else if( Peek() == '*' ) result = HandleSimpleToken( TokenType.Mult );
@@ -108,11 +110,36 @@ namespace NS.CalviScript
 
         void Forward() => _pos++;
 
+        /// <summary>
+        /// Moves forward two times.
+        /// </summary>
+        void SkipMultilineComment()
+        {
+            Forward();
+            Forward();
+        }
+
         char Peek( int offset ) => _input[ _pos + offset ];
 
-        public bool IsEnd => _pos >= _input.Length;
+        /// <summary>
+        /// Checks if the current position has reached the End Of Input (EOI).
+        /// </summary>
+        /// <returns>True if the current position is greater than or equal to the input length.</returns>
+        public bool IsEnd() => IsEnd(0);
+
+        /// <summary>
+        /// Checks if the current position plus an offset has reached the End Of Input (EOI).
+        /// </summary>
+        /// <param name="offset">True if the current position plus the offset is greater than or equal to the input length.</param>
+        /// <returns></returns>
+        public bool IsEnd(int offset) => _pos + offset >= _input.Length;
 
         bool IsComment => _pos < _input.Length - 1 && Peek() == '/' && Peek( 1 ) == '/';
+
+        /// <summary>
+        /// Checks if there is a multi line comment ahead in the input.
+        /// </summary>
+        bool IsMultiLineComment => !IsEnd(1) && Peek() == '/' && Peek(1) == '*';
 
         void HandleComment()
         {
@@ -121,7 +148,39 @@ namespace NS.CalviScript
             do
             {
                 Forward();
-            } while( !IsEnd && Peek() != '\r' && Peek() != '\n' );
+            } while( !IsEnd() && Peek() != '\r' && Peek() != '\n' );
+        }
+
+        /// <summary>
+        /// Moves forward until the closing muliline comment is found.
+        /// Supports nested multiline comments with recursive calls.
+        /// Multilines comments must be closed before the end of file.
+        /// </summary>
+        /// <returns>A new <see cref="Token"/> of type <see cref="TokenType.Error"/>
+        /// if the EOI is reached before the last closing comment.</returns>
+        Token HandleMultiLineComment()
+        {
+            Debug.Assert(IsMultiLineComment);
+
+            Token error = null;
+            SkipMultilineComment();
+            while (!IsEnd(1) && !(Peek() == '*' && Peek(1) == '/'))
+            {
+                if (IsMultiLineComment)
+                {
+                    if ((error = HandleMultiLineComment()) != null)
+                        return error;
+                }
+                else
+                    Forward();
+            }
+
+            if (IsEnd(1))
+                error = new Token(TokenType.Error, "Expected <*/>, but <EOI> found.");
+            if (error == null)
+                SkipMultilineComment();
+
+            return error;
         }
 
         bool IsWhiteSpace => char.IsWhiteSpace( Peek() );
@@ -133,7 +192,7 @@ namespace NS.CalviScript
             do
             {
                 Forward();
-            } while( !IsEnd && IsWhiteSpace );
+            } while( !IsEnd() && IsWhiteSpace );
         }
 
         bool IsNumber => char.IsDigit( Peek() );
@@ -151,7 +210,7 @@ namespace NS.CalviScript
             if( Peek() == '0' )
             {
                 Forward();
-                if( !IsEnd && (IsNumber || IsIdentifier) ) return new Token( TokenType.Error, "0" + Peek() );
+                if( !IsEnd() && (IsNumber || IsIdentifier) ) return new Token( TokenType.Error, "0" + Peek() );
                 return new Token( TokenType.Number, '0' );
             }
 
@@ -160,9 +219,9 @@ namespace NS.CalviScript
             {
                 sb.Append( Peek() );
                 Forward();
-            } while( !IsEnd && IsNumber );
+            } while( !IsEnd() && IsNumber );
 
-            if (!IsEnd && IsIdentifier)
+            if (!IsEnd() && IsIdentifier)
             {
                 sb.Append(Peek());
                 return new Token(TokenType.Error, sb.ToString());
@@ -182,7 +241,7 @@ namespace NS.CalviScript
             {
                 sb.Append( Peek() );
                 Forward();
-            } while( !IsEnd && ( IsIdentifier || char.IsDigit( Peek() ) ) );
+            } while( !IsEnd() && ( IsIdentifier || char.IsDigit( Peek() ) ) );
 
             string identifier = sb.ToString();
             if( identifier == "var" ) return new Token( TokenType.Var, identifier );


### PR DESCRIPTION
As @antoine-r suggested, we can add support for **nested** multi line comments.
This means a closing multi line comment will close the last opening multi line comment.
Thus, a code like this should work and the program should evaluate to 1:

```javascript
var a = 1;
/*
    /*
        a = 2;
    */
    // The GitHub/markdown syntax coloring (for JavaScript) thinks this is an instruction,
    // whereas this is still a comment in CalviScript.
    a = 3;
*/
a;
```

To support multi line comments, we have to look for the end of the input not only for the current token, but for the next one as well.
Thus, I modified the IsEnd property into a method which take one optional argument (thanks to method overloading) for the offset.
I should have made a separate commit for that, sorry.